### PR TITLE
Dockerfile improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDEs
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
-# Use the official Golang image as the base image
-FROM golang:1.16-alpine
+# Use the official Golang image as the base image - https://hub.docker.com/_/golang/tags
+FROM golang:1.20-alpine as builder
 
 # Set the working directory
 WORKDIR /app
 
-# Copy go.mod and go.sum files to the container
-COPY go.mod go.sum ./
+# Copy source to this builder container
+COPY . /app
 
-# Download dependencies
-RUN go mod download
-
-# Copy the source code to the container
-COPY . .
+# Download build dependencies
+RUN go get github.com/codingo/dorky
 
 # Build the application
 RUN go build -o main .
 
-# Set the entrypoint for the container
+# Bump the application with --help to know it was built
+RUN /app/main --help
+
+
+# Use an Alpine container to deploy/run the application from - https://hub.docker.com/_/alpine/tags
+FROM alpine:3.18
+
+WORKDIR /app
+COPY --from=builder /app/main /app/main
+
 ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
Rework the Dockerfile breaking it into a two stage process, build and deployment.

Adjust the way the build dependencies are collected using a `go get github.com/codingo/dorky` to deal with the otherwise missing `go.sum` file.

Use deployment container alpine:3.18

Update golang:1.16 to golang:1.20

Container build size before
> dorky 20230514z155300-dev 260e83175fca 374MB

Container build size after
> dorky 20230514z155514-dev d3b7c5c86bd6 15.3MB